### PR TITLE
Add custom subsection group prefix title support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Within the reStructuredText files use the `sphinx_argparse_cli` directive that t
 | prog        | (optional) the module path to where the parser is defined                                                                     |
 | title       | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included |
 | usage_width | (optional) how large should usage examples be - defaults to 100 character                                                     |
+| group_title_prefix | (optional) changes groups subsections title prefixes - defaults to `<prog>` |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Within the reStructuredText files use the `sphinx_argparse_cli` directive that t
 | prog        | (optional) the module path to where the parser is defined                                                                     |
 | title       | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included |
 | usage_width | (optional) how large should usage examples be - defaults to 100 character                                                     |
-| group_title_prefix | (optional) groups subsection title prefixes - defaults to `<prog>` |
+| group_title_prefix | (optional) groups subsections title prefixes - defaults to `<prog>` |
+| group_sub_title_prefix | (optional) subcommands groups subsections title prefixes - defaults to `<prog> <subcommand>` |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Within the reStructuredText files use the `sphinx_argparse_cli` directive that t
 | prog        | (optional) the module path to where the parser is defined                                                                     |
 | title       | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included |
 | usage_width | (optional) how large should usage examples be - defaults to 100 character                                                     |
-| group_title_prefix | (optional) groups subsections title prefixes - defaults to `<prog>` |
-| group_sub_title_prefix | (optional) subcommands groups subsections title prefixes - defaults to `<prog> <subcommand>` |
+| group_title_prefix | (optional) groups subsections title prefixes, accepts the string `{prog}` as a replacement for the program name - defaults to `{prog}` |
+| group_sub_title_prefix | (optional) subcommands groups subsections title prefixes, accepts replacement of `{prog}` and `{subcommand}` for program and subcommand name - defaults to `{prog} {subcommand}` |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ extensions = ["sphinx_argparse_cli"]
 
 Within the reStructuredText files use the `sphinx_argparse_cli` directive that takes, at least, two arguments:
 
-| Name        | Description                                                                                                                   |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| module      | the module path to where the parser is defined                                                                                |
-| func        | the name of the function that once called with no arguments constructs the parser                                             |
-| prog        | (optional) the module path to where the parser is defined                                                                     |
-| title       | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included |
-| usage_width | (optional) how large should usage examples be - defaults to 100 character                                                     |
-| group_title_prefix | (optional) groups subsections title prefixes, accepts the string `{prog}` as a replacement for the program name - defaults to `{prog}` |
+| Name                   | Description                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| module                 | the module path to where the parser is defined                                                                                                                                   |
+| func                   | the name of the function that once called with no arguments constructs the parser                                                                                                |
+| prog                   | (optional) the module path to where the parser is defined                                                                                                                        |
+| title                  | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included                                                    |
+| usage_width            | (optional) how large should usage examples be - defaults to 100 character                                                                                                        |
+| group_title_prefix     | (optional) groups subsections title prefixes, accepts the string `{prog}` as a replacement for the program name - defaults to `{prog}`                                           |
 | group_sub_title_prefix | (optional) subcommands groups subsections title prefixes, accepts replacement of `{prog}` and `{subcommand}` for program and subcommand name - defaults to `{prog} {subcommand}` |
 
 For example:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Within the reStructuredText files use the `sphinx_argparse_cli` directive that t
 | prog        | (optional) the module path to where the parser is defined                                                                     |
 | title       | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included |
 | usage_width | (optional) how large should usage examples be - defaults to 100 character                                                     |
-| group_title_prefix | (optional) changes groups subsections title prefixes - defaults to `<prog>` |
+| group_title_prefix | (optional) groups subsection title prefixes - defaults to `<prog>` |
 
 For example:
 

--- a/roots/test-group-title-empty-prefixes/conf.py
+++ b/roots/test-group-title-empty-prefixes/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-empty-prefixes/index.rst
+++ b/roots/test-group-title-empty-prefixes/index.rst
@@ -1,4 +1,5 @@
 .. sphinx_argparse_cli::
   :module: parser
   :func: make
-  :group_sub_title_prefix: custom
+  :group_title_prefix:
+  :group_sub_title_prefix:

--- a/roots/test-group-title-empty-prefixes/parser.py
+++ b/roots/test-group-title-empty-prefixes/parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="complex")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    parser.add_argument("--no-help", action="store_true")
+    parser.add_argument("--outdir", "-o", type=str, help="output directory", metavar="out_dir")
+    parser.add_argument("--in-dir", "-i", type=str, help="input directory", dest="in_dir")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
+
+    sub_parsers_a.add_parser("third")  # empty sub-command
+    return parser

--- a/roots/test-group-title-prefix-custom-subcommands/conf.py
+++ b/roots/test-group-title-prefix-custom-subcommands/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-custom-subcommands/index.rst
+++ b/roots/test-group-title-prefix-custom-subcommands/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix: custom

--- a/roots/test-group-title-prefix-custom-subcommands/index.rst
+++ b/roots/test-group-title-prefix-custom-subcommands/index.rst
@@ -2,3 +2,16 @@
   :module: parser
   :func: make
   :group_sub_title_prefix: custom
+
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix:
+  :group_sub_title_prefix: custom-2
+
+
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix: myprog
+  :group_sub_title_prefix: custom-3

--- a/roots/test-group-title-prefix-custom-subcommands/parser.py
+++ b/roots/test-group-title-prefix-custom-subcommands/parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="complex")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    parser.add_argument("--no-help", action="store_true")
+    parser.add_argument("--outdir", "-o", type=str, help="output directory", metavar="out_dir")
+    parser.add_argument("--in-dir", "-i", type=str, help="input directory", dest="in_dir")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
+
+    sub_parsers_a.add_parser("third")  # empty sub-command
+    return parser

--- a/roots/test-group-title-prefix-custom/conf.py
+++ b/roots/test-group-title-prefix-custom/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-custom/index.rst
+++ b/roots/test-group-title-prefix-custom/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix: custom

--- a/roots/test-group-title-prefix-custom/parser.py
+++ b/roots/test-group-title-prefix-custom/parser.py
@@ -7,4 +7,27 @@ def make() -> ArgumentParser:
     parser = ArgumentParser(description="argparse tester", prog="prog")
     parser.add_argument("root")
     parser.add_argument("--root", action="store_true", help="root flag")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
     return parser

--- a/roots/test-group-title-prefix-custom/parser.py
+++ b/roots/test-group-title-prefix-custom/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="prog")
+    parser.add_argument("root")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    return parser

--- a/roots/test-group-title-prefix-default/conf.py
+++ b/roots/test-group-title-prefix-default/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-default/index.rst
+++ b/roots/test-group-title-prefix-default/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+

--- a/roots/test-group-title-prefix-default/index.rst
+++ b/roots/test-group-title-prefix-default/index.rst
@@ -1,4 +1,3 @@
 .. sphinx_argparse_cli::
   :module: parser
   :func: make
-

--- a/roots/test-group-title-prefix-default/parser.py
+++ b/roots/test-group-title-prefix-default/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="prog")
+    parser.add_argument("root")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    return parser

--- a/roots/test-group-title-prefix-empty-subcommands/conf.py
+++ b/roots/test-group-title-prefix-empty-subcommands/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-empty-subcommands/index.rst
+++ b/roots/test-group-title-prefix-empty-subcommands/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix:

--- a/roots/test-group-title-prefix-empty-subcommands/index.rst
+++ b/roots/test-group-title-prefix-empty-subcommands/index.rst
@@ -2,3 +2,10 @@
   :module: parser
   :func: make
   :group_sub_title_prefix:
+
+
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix: myprog
+  :group_sub_title_prefix:

--- a/roots/test-group-title-prefix-empty-subcommands/index.rst
+++ b/roots/test-group-title-prefix-empty-subcommands/index.rst
@@ -1,4 +1,4 @@
 .. sphinx_argparse_cli::
   :module: parser
   :func: make
-  :group_title_prefix:
+  :group_sub_title_prefix:

--- a/roots/test-group-title-prefix-empty-subcommands/parser.py
+++ b/roots/test-group-title-prefix-empty-subcommands/parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="complex")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    parser.add_argument("--no-help", action="store_true")
+    parser.add_argument("--outdir", "-o", type=str, help="output directory", metavar="out_dir")
+    parser.add_argument("--in-dir", "-i", type=str, help="input directory", dest="in_dir")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
+
+    sub_parsers_a.add_parser("third")  # empty sub-command
+    return parser

--- a/roots/test-group-title-prefix-empty/conf.py
+++ b/roots/test-group-title-prefix-empty/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-empty/index.rst
+++ b/roots/test-group-title-prefix-empty/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix:

--- a/roots/test-group-title-prefix-empty/parser.py
+++ b/roots/test-group-title-prefix-empty/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="prog")
+    parser.add_argument("root")
+    parser.add_argument("--root", action="store_true", help="root flag")
+    return parser

--- a/roots/test-group-title-prefix-prog-replacement/conf.py
+++ b/roots/test-group-title-prefix-prog-replacement/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-prog-replacement/index.rst
+++ b/roots/test-group-title-prefix-prog-replacement/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_title_prefix: {prog}foo

--- a/roots/test-group-title-prefix-prog-replacement/parser.py
+++ b/roots/test-group-title-prefix-prog-replacement/parser.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="bar")
+    parser.add_argument("root")
+    parser.add_argument("--root", action="store_true", help="root flag")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
+    return parser

--- a/roots/test-group-title-prefix-subcommand-replacement/conf.py
+++ b/roots/test-group-title-prefix-subcommand-replacement/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-group-title-prefix-subcommand-replacement/index.rst
+++ b/roots/test-group-title-prefix-subcommand-replacement/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :group_sub_title_prefix: {prog}only{subcommand}

--- a/roots/test-group-title-prefix-subcommand-replacement/parser.py
+++ b/roots/test-group-title-prefix-subcommand-replacement/parser.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(description="argparse tester", prog="bar")
+    parser.add_argument("root")
+    parser.add_argument("--root", action="store_true", help="root flag")
+
+    group = parser.add_argument_group("Exclusive", description="this is an exclusive group")
+    exclusive = group.add_mutually_exclusive_group()
+    exclusive.add_argument("--foo", action="store_true", help="foo")
+    exclusive.add_argument("--bar", action="store_true", help="bar")
+
+    parser.add_argument_group("empty")
+
+    sub_parsers_a = parser.add_subparsers(title="sub-parser-a", description="sub parsers A", dest="command")
+    sub_parsers_a.required = False
+    sub_parsers_a.default = "first"
+
+    a_parser_first = sub_parsers_a.add_parser("first", aliases=["f"], help="a-first-help", description="a-first-desc")
+    a_parser_first.add_argument("--flag", dest="a_par_first_flag", action="store_true", help="a parser first flag")
+    a_parser_first.add_argument("--root", action="store_true", help="root flag")
+    a_parser_first.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_first.add_argument("pos_two", help="second positional argument", default=1)
+
+    a_parser_second = sub_parsers_a.add_parser("second")
+    a_parser_second.add_argument("--flag", dest="a_par_second_flag", action="store_true", help="a parser second flag")
+    a_parser_second.add_argument("--root", action="store_true", help="root flag")
+    a_parser_second.add_argument("pos_one", help="first positional argument", metavar="one")
+    a_parser_second.add_argument("pos_two", help="second positional argument", default="green")
+    return parser

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -129,12 +129,11 @@ class SphinxArgparseCli(SphinxDirective):
         return [home_section]
 
     def _mk_option_group(self, group: _ArgumentGroup, prefix: str) -> section:
-        group_title_prefix : str = (
-            prefix if self.options["group_title_prefix"] is None
-            else self.options["group_title_prefix"]
+        group_title_prefix: str = (
+            prefix if self.options["group_title_prefix"] is None else self.options["group_title_prefix"]
         )
-        title_text : str = f"{group_title_prefix}{' ' if group_title_prefix else ''}{group.title}"
-        title_ref : str = f"{prefix}{' ' if prefix else ''}{group.title}"
+        title_text: str = f"{group_title_prefix}{' ' if group_title_prefix else ''}{group.title}"
+        title_ref: str = f"{prefix}{' ' if prefix else ''}{group.title}"
         ref_id = make_id(title_ref)
         # the text sadly needs to be prefixed, because otherwise the autosectionlabel will conflict
         header = title("", Text(title_text))

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -145,7 +145,7 @@ class SphinxArgparseCli(SphinxDirective):
                     if sub_title_prefix:
                         sub_title_prefix = sub_title_prefix.replace("{prog}", prefix.split(" ")[0]).replace(
                             "{subcommand}",
-                            prefix.split(" ")[1:],
+                            " ".join(prefix.split(" ")[1:]),
                         )
 
                         title_text += f"{sub_title_prefix} "

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -7,7 +7,7 @@ from argparse import _ArgumentGroup  # noqa
 from argparse import _SubParsersAction  # noqa
 from argparse import SUPPRESS, Action, ArgumentParser, HelpFormatter
 from collections import defaultdict, namedtuple
-from typing import Iterator, Optional, cast
+from typing import Iterator, cast
 
 from docutils.nodes import (
     Element,

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -246,12 +246,10 @@ class SphinxArgparseCli(SphinxDirective):
                 if sub_title_prefix:
                     title_text += f"{sub_title_prefix} "
             else:
-                if " " in parser.prog:
-                    title_text += parser.prog.split(" ")[1]
+                title_text += parser.prog.split(" ")[1]
         else:
             if sub_title_prefix is not None:
-                if " " in parser.prog:
-                    title_text += f"{parser.prog.split(' ')[0]} "
+                title_text += f"{parser.prog.split(' ')[0]} "
                 if sub_title_prefix:
                     title_text += f"{sub_title_prefix} "
             else:

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -51,6 +51,7 @@ class SphinxArgparseCli(SphinxDirective):
         "prog": unchanged,
         "title": unchanged,
         "usage_width": positive_int,
+        "group_title_prefix": unchanged,
     }
 
     def __init__(
@@ -65,6 +66,8 @@ class SphinxArgparseCli(SphinxDirective):
         state: RSTState,
         state_machine: RSTStateMachine,
     ):
+        if "group_title_prefix" not in options:
+            options["group_title_prefix"] = None
         super().__init__(name, arguments, options, content, lineno, content_offset, block_text, state, state_machine)
         self._parser: ArgumentParser | None = None
         self._std_domain: StandardDomain = cast(StandardDomain, self.env.get_domain("std"))
@@ -126,8 +129,13 @@ class SphinxArgparseCli(SphinxDirective):
         return [home_section]
 
     def _mk_option_group(self, group: _ArgumentGroup, prefix: str) -> section:
-        title_text = f"{prefix}{' ' if prefix else ''}{group.title}"
-        ref_id = make_id(title_text)
+        group_title_prefix : str = (
+            prefix if self.options["group_title_prefix"] is None
+            else self.options["group_title_prefix"]
+        )
+        title_text : str = f"{group_title_prefix}{' ' if group_title_prefix else ''}{group.title}"
+        title_ref : str = f"{prefix}{' ' if prefix else ''}{group.title}"
+        ref_id = make_id(title_ref)
         # the text sadly needs to be prefixed, because otherwise the autosectionlabel will conflict
         header = title("", Text(title_text))
         group_section = section("", header, ids=[ref_id], names=[ref_id])

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -7,7 +7,7 @@ from argparse import _ArgumentGroup  # noqa
 from argparse import _SubParsersAction  # noqa
 from argparse import SUPPRESS, Action, ArgumentParser, HelpFormatter
 from collections import defaultdict, namedtuple
-from typing import Iterator, cast
+from typing import Iterator, Optional, cast
 
 from docutils.nodes import (
     Element,
@@ -58,7 +58,7 @@ class SphinxArgparseCli(SphinxDirective):
         self,
         name: str,
         arguments: list[str],
-        options: dict[str, str],
+        options: dict[str, str | None],
         content: StringList,
         lineno: int,
         content_offset: int,
@@ -66,8 +66,7 @@ class SphinxArgparseCli(SphinxDirective):
         state: RSTState,
         state_machine: RSTStateMachine,
     ):
-        if "group_title_prefix" not in options:
-            options["group_title_prefix"] = None
+        options.setdefault("group_title_prefix", None)  # noqa: SC200
         super().__init__(name, arguments, options, content, lineno, content_offset, block_text, state, state_machine)
         self._parser: ArgumentParser | None = None
         self._std_domain: StandardDomain = cast(StandardDomain, self.env.get_domain("std"))

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -137,8 +137,7 @@ class SphinxArgparseCli(SphinxDirective):
                 title_text += f"{' '.join(prefix.split(' ')[1:])} "
         else:
             title_text += f"{prefix} "
-        if group.title:
-            title_text += group.title
+        title_text += group.title or ""
 
         title_ref: str = f"{prefix}{' ' if prefix else ''}{group.title}"
         ref_id = make_id(title_ref)

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -136,11 +136,18 @@ class SphinxArgparseCli(SphinxDirective):
 
         if title_prefix is not None:
             if title_prefix:
+                title_prefix = title_prefix.replace("{prog}", prefix.split(" ")[0])
+
                 title_text += f"{title_prefix} "
 
             if " " in prefix:
                 if sub_title_prefix is not None:
                     if sub_title_prefix:
+                        sub_title_prefix = sub_title_prefix.replace("{prog}", prefix.split(" ")[0]).replace(
+                            "{subcommand}",
+                            prefix.split(" ")[1:],
+                        )
+
                         title_text += f"{sub_title_prefix} "
                 else:
                     title_text += f"{' '.join(prefix.split(' ')[1:])} "
@@ -149,6 +156,11 @@ class SphinxArgparseCli(SphinxDirective):
                 if sub_title_prefix is not None:
                     title_text += f"{prefix.split(' ')[0]} "
                     if sub_title_prefix:
+                        sub_title_prefix = sub_title_prefix.replace("{prog}", prefix.split(" ")[0]).replace(
+                            "{subcommand}",
+                            " ".join(prefix.split(" ")[1:]),
+                        )
+
                         title_text += f"{sub_title_prefix} "
                 else:
                     title_text += f"{' '.join(prefix.split(' ')[:2])} "
@@ -240,10 +252,17 @@ class SphinxArgparseCli(SphinxDirective):
         title_prefix: str = self.options["group_title_prefix"]
         title_text: str = ""
         if title_prefix is not None:
+            title_prefix = title_prefix.replace("{prog}", parser.prog.split(" ")[0])
+
             if title_prefix:
                 title_text += f"{title_prefix} "
             if sub_title_prefix is not None:
                 if sub_title_prefix:
+                    sub_title_prefix = sub_title_prefix.replace("{prog}", parser.prog.split(" ")[0],).replace(
+                        "{subcommand}",
+                        parser.prog.split(" ")[1],
+                    )
+
                     title_text += f"{sub_title_prefix} "
             else:
                 title_text += parser.prog.split(" ")[1]
@@ -251,6 +270,11 @@ class SphinxArgparseCli(SphinxDirective):
             if sub_title_prefix is not None:
                 title_text += f"{parser.prog.split(' ')[0]} "
                 if sub_title_prefix:
+                    sub_title_prefix = sub_title_prefix.replace("{prog}", parser.prog.split(" ")[0],).replace(
+                        "{subcommand}",
+                        parser.prog.split(" ")[1],
+                    )
+
                     title_text += f"{sub_title_prefix} "
             else:
                 title_text += parser.prog

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -137,7 +137,6 @@ class SphinxArgparseCli(SphinxDirective):
         if title_prefix is not None:
             if title_prefix:
                 title_prefix = title_prefix.replace("{prog}", prefix.split(" ")[0])
-
                 title_text += f"{title_prefix} "
 
             if " " in prefix:

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -137,7 +137,8 @@ class SphinxArgparseCli(SphinxDirective):
                 title_text += f"{' '.join(prefix.split(' ')[1:])} "
         else:
             title_text += f"{prefix} "
-        title_text += group.title
+        if group.title:
+            title_text += group.title
 
         title_ref: str = f"{prefix}{' ' if prefix else ''}{group.title}"
         ref_id = make_id(title_ref)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -139,3 +139,29 @@ def test_group_title_prefix_empty(build_outcome: str) -> None:
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom")
 def test_group_title_prefix_custom(build_outcome: str) -> None:
     assert ('<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom-subcommands")
+def test_group_title_prefix_custom_sub_commands(build_outcome: str) -> None:
+    assert '<h2>custom Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
+    assert '<h2>custom first (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
+    assert (
+        '<h3>custom first positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+    ) in build_outcome
+    assert (
+        '<h3>custom first optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    ) in build_outcome
+    assert '<h2>custom second<a class="headerlink" href="#complex-second"' in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty-subcommands")
+def test_group_title_prefix_empty_sub_commands(build_outcome: str) -> None:
+    assert '<h2>Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
+    assert '<h2>first (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
+    assert (
+        '<h3>first positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+    ) in build_outcome
+    assert (
+        '<h3>first optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    ) in build_outcome
+    assert '<h2>second<a class="headerlink" href="#complex-second"' in build_outcome

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -154,6 +154,14 @@ def test_group_title_prefix_custom_sub_commands(build_outcome: str) -> None:
     ) in build_outcome
     assert '<h2>complex custom<a class="headerlink" href="#complex-second"' in build_outcome
 
+    assert (
+        '<h3>custom-2 optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    ) in build_outcome
+
+    assert (
+        '<h3>myprog custom-3 optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
+    ) in build_outcome
+
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty-subcommands")
 def test_group_title_prefix_empty_sub_commands(build_outcome: str) -> None:
@@ -166,6 +174,10 @@ def test_group_title_prefix_empty_sub_commands(build_outcome: str) -> None:
         '<h3>complex optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
     ) in build_outcome
     assert '<h2>complex<a class="headerlink" href="#complex-second"' in build_outcome
+
+    assert (
+        '<h3>myprog optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
+    ) in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-empty-prefixes")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -143,25 +143,35 @@ def test_group_title_prefix_custom(build_outcome: str) -> None:
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom-subcommands")
 def test_group_title_prefix_custom_sub_commands(build_outcome: str) -> None:
-    assert '<h2>custom Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
-    assert '<h2>custom first (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
+    assert '<h2>complex Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
+
+    assert '<h2>complex custom (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
     assert (
-        '<h3>custom first positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+        '<h3>complex custom positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
     ) in build_outcome
     assert (
-        '<h3>custom first optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+        '<h3>complex custom optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
     ) in build_outcome
-    assert '<h2>custom second<a class="headerlink" href="#complex-second"' in build_outcome
+    assert '<h2>complex custom<a class="headerlink" href="#complex-second"' in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty-subcommands")
 def test_group_title_prefix_empty_sub_commands(build_outcome: str) -> None:
+    assert '<h2>complex Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
+    assert '<h2>complex (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
+    assert (
+        '<h3>complex positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+    ) in build_outcome
+    assert (
+        '<h3>complex optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    ) in build_outcome
+    assert '<h2>complex<a class="headerlink" href="#complex-second"' in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-empty-prefixes")
+def test_group_title_empty_prefixes(build_outcome: str) -> None:
     assert '<h2>Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
-    assert '<h2>first (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
-    assert (
-        '<h3>first positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
-    ) in build_outcome
-    assert (
-        '<h3>first optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
-    ) in build_outcome
-    assert '<h2>second<a class="headerlink" href="#complex-second"' in build_outcome
+    assert '<h2>(f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
+    assert ('<h3>positional arguments<a class="headerlink" href="#complex-first-positional-arguments"') in build_outcome
+    assert ('<h3>optional arguments<a class="headerlink" href="#complex-first-optional-arguments"') in build_outcome
+    assert '<h2><a class="headerlink" href="#complex-second"' in build_outcome

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -141,6 +141,11 @@ def test_group_title_prefix_custom(build_outcome: str) -> None:
     assert '<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"' in build_outcome
 
 
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-prog-replacement")
+def test_group_title_prefix_prog_replacement(build_outcome: str) -> None:
+    assert '<h2>barfoo positional arguments<a class="headerlink" href="#bar-positional-arguments"' in build_outcome
+
+
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom-subcommands")
 def test_group_title_prefix_custom_sub_commands(build_outcome: str) -> None:
     assert '<h2>complex Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
@@ -187,3 +192,11 @@ def test_group_title_empty_prefixes(build_outcome: str) -> None:
     assert ('<h3>positional arguments<a class="headerlink" href="#complex-first-positional-arguments"') in build_outcome
     assert ('<h3>optional arguments<a class="headerlink" href="#complex-first-optional-arguments"') in build_outcome
     assert '<h2><a class="headerlink" href="#complex-second"' in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-subcommand-replacement")
+def test_group_title_prefix_sub_command_replacement(build_outcome: str) -> None:
+    assert '<h2>bar optional arguments<a class="headerlink" href="#bar-optional-arguments"' in build_outcome
+    assert '<h2>bar Exclusive<a class="headerlink" href="#bar-exclusive"' in build_outcome
+    assert '<h2>bar baronlyroot (f)<a class="headerlink" href="#bar-root-first-(f)"' in build_outcome
+    assert '<h3>bar baronlyroot first positional arguments<a class="headerlink"' in build_outcome

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -124,3 +124,24 @@ def test_ref_duplicate_label(build_outcome: tuple[str, str]) -> None:
     assert build_outcome
     warnings = _REF_WARNING_STRING_IO.getvalue()
     assert "duplicate label prog---help" in warnings
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-default")
+def test_group_title_prefix_default(build_outcome: str) -> None:
+    assert (
+        '<h2>prog positional arguments<a class="headerlink" href="#prog-positional-arguments"'
+    ) in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty")
+def test_group_title_prefix_empty(build_outcome: str) -> None:
+    assert (
+        '<h2>positional arguments<a class="headerlink" href="#prog-positional-arguments"'
+    ) in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom")
+def test_group_title_prefix_custom(build_outcome: str) -> None:
+    assert (
+        '<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"'
+    ) in build_outcome

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -149,48 +149,37 @@ def test_group_title_prefix_prog_replacement(build_outcome: str) -> None:
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom-subcommands")
 def test_group_title_prefix_custom_sub_commands(build_outcome: str) -> None:
     assert '<h2>complex Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
-
     assert '<h2>complex custom (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
-    assert (
-        '<h3>complex custom positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
-    ) in build_outcome
-    assert (
-        '<h3>complex custom optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
-    ) in build_outcome
+    msg = '<h3>complex custom positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+    assert msg in build_outcome
+    msg = '<h3>complex custom optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    assert msg in build_outcome
     assert '<h2>complex custom<a class="headerlink" href="#complex-second"' in build_outcome
-
-    assert (
-        '<h3>custom-2 optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
-    ) in build_outcome
-
-    assert (
-        '<h3>myprog custom-3 optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
-    ) in build_outcome
+    msg = '<h3>custom-2 optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    assert msg in build_outcome
+    msg = '<h3>myprog custom-3 optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
+    assert msg in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty-subcommands")
 def test_group_title_prefix_empty_sub_commands(build_outcome: str) -> None:
     assert '<h2>complex Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
     assert '<h2>complex (f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
-    assert (
-        '<h3>complex positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
-    ) in build_outcome
-    assert (
-        '<h3>complex optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
-    ) in build_outcome
+    msg = '<h3>complex positional arguments<a class="headerlink" href="#complex-first-positional-arguments"'
+    assert msg in build_outcome
+    msg = '<h3>complex optional arguments<a class="headerlink" href="#complex-first-optional-arguments"'
+    assert msg in build_outcome
     assert '<h2>complex<a class="headerlink" href="#complex-second"' in build_outcome
-
-    assert (
-        '<h3>myprog optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
-    ) in build_outcome
+    msg = '<h3>myprog optional arguments<a class="headerlink" href="#complex-second-optional-arguments"'
+    assert msg in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-empty-prefixes")
 def test_group_title_empty_prefixes(build_outcome: str) -> None:
     assert '<h2>Exclusive<a class="headerlink" href="#complex-exclusive"' in build_outcome
     assert '<h2>(f)<a class="headerlink" href="#complex-first-(f)"' in build_outcome
-    assert ('<h3>positional arguments<a class="headerlink" href="#complex-first-positional-arguments"') in build_outcome
-    assert ('<h3>optional arguments<a class="headerlink" href="#complex-first-optional-arguments"') in build_outcome
+    assert '<h3>positional arguments<a class="headerlink" href="#complex-first-positional-arguments"' in build_outcome
+    assert '<h3>optional arguments<a class="headerlink" href="#complex-first-optional-arguments"' in build_outcome
     assert '<h2><a class="headerlink" href="#complex-second"' in build_outcome
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -128,20 +128,14 @@ def test_ref_duplicate_label(build_outcome: tuple[str, str]) -> None:
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-default")
 def test_group_title_prefix_default(build_outcome: str) -> None:
-    assert (
-        '<h2>prog positional arguments<a class="headerlink" href="#prog-positional-arguments"'
-    ) in build_outcome
+    assert ('<h2>prog positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty")
 def test_group_title_prefix_empty(build_outcome: str) -> None:
-    assert (
-        '<h2>positional arguments<a class="headerlink" href="#prog-positional-arguments"'
-    ) in build_outcome
+    assert ('<h2>positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom")
 def test_group_title_prefix_custom(build_outcome: str) -> None:
-    assert (
-        '<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"'
-    ) in build_outcome
+    assert ('<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -128,17 +128,17 @@ def test_ref_duplicate_label(build_outcome: tuple[str, str]) -> None:
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-default")
 def test_group_title_prefix_default(build_outcome: str) -> None:
-    assert ('<h2>prog positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
+    assert '<h2>prog positional arguments<a class="headerlink" href="#prog-positional-arguments"' in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-empty")
 def test_group_title_prefix_empty(build_outcome: str) -> None:
-    assert ('<h2>positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
+    assert '<h2>positional arguments<a class="headerlink" href="#prog-positional-arguments"' in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom")
 def test_group_title_prefix_custom(build_outcome: str) -> None:
-    assert ('<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"') in build_outcome
+    assert '<h2>custom positional arguments<a class="headerlink" href="#prog-positional-arguments"' in build_outcome
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-custom-subcommands")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,6 +3,7 @@ anonlabels
 autosectionlabel
 buildername
 confdir
+cmd
 desc
 dest
 doc2path
@@ -11,6 +12,7 @@ docutils
 formatter
 Formatter
 fromlist
+grp
 lineno
 linesep
 metavar

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -27,3 +27,4 @@ subparsers
 subtype
 testroot
 util
+setdefault


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Closes #11

**Describe your changes**
The purpose is detailed in issue #11, this change adds the option `group_title_prefix` which accepts a string. If not provided, the prefix added to titles of groups subsections is the `<prog>` itself, but providing some string, this prefix will be changed, without overriding the `#<prog>-...` in hrefs.

**Testing performed**
Multiple tests added.

**Additional context**
`setdefault` [is not allowed by flake8-spellcheck](https://github.com/MichaelAquilina/flake8-spellcheck/pull/49).